### PR TITLE
Add shared SimplifiedWeather type

### DIFF
--- a/types/SimplifiedWeather.ts
+++ b/types/SimplifiedWeather.ts
@@ -1,0 +1,20 @@
+export interface SimplifiedWeather {
+  /** Temperature in degrees Celsius */
+  temperature: number;
+  /** Main weather condition, e.g. "Clouds" */
+  condition: string;
+  /** More detailed description of the condition */
+  description?: string;
+  /** Icon code from the API, if available */
+  icon?: string;
+  /** Relative humidity percentage */
+  humidity: number;
+  /** Atmospheric pressure in hPa */
+  pressure: number;
+  /** Wind speed in meters per second */
+  windSpeed: number;
+  /** Wind direction in degrees */
+  windDirection: number;
+  /** Rain volume for the last 3 hours in mm, if provided */
+  rainVolume?: number;
+}


### PR DESCRIPTION
## Summary
- define `SimplifiedWeather` interface for AI features

## Testing
- `npm test --prefix client`
- `npm test --prefix server` *(fails: Cannot find module '../internal/lrucache')*

------
https://chatgpt.com/codex/tasks/task_e_687b4bf4d13083298f90ecfdb013ba19