### PR TITLE
Add weather summary utility

### DIFF
--- a/server/summarizeWeather.test.ts
+++ b/server/summarizeWeather.test.ts
@@ -1,0 +1,22 @@
+import { summarizeWeather } from "./utils/summarizeWeather";
+import { SimplifiedWeather } from "../types/SimplifiedWeather";
+
+describe("summarizeWeather", () => {
+  it("creates a readable summary from weather data", () => {
+    const weather: SimplifiedWeather = {
+      temperature: 14,
+      condition: "Clouds",
+      description: "cloudy",
+      humidity: 70,
+      pressure: 1015,
+      wind: {
+        speed: 3,
+        direction: 180,
+      },
+      rainVolume: 0.2,
+    };
+
+    const summary = summarizeWeather(weather);
+    expect(summary).toBe("14°C, cloudy, chance of rain, light wind");
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "types": ["jest"],
+    "types": ["jest", "node"],
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -107,7 +107,7 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"],
+  // "exclude": ["**/*.test.ts", "**/*.spec.ts"],
   "include": [
     "**/*.ts", // include all TypeScript files in the server directory and subdirectories
     "jest.config.ts" // include Jest configuration

--- a/server/utils/summarizeWeather.ts
+++ b/server/utils/summarizeWeather.ts
@@ -1,0 +1,39 @@
+import { SimplifiedWeather } from "../../types/SimplifiedWeather";
+
+/**
+ * Convert a SimplifiedWeather object into a short, human readable summary.
+ * Example output: "14°C, cloudy, chance of rain, light wind".
+ * This string is suitable for LLM prompt injection.
+ */
+export function summarizeWeather(weather: SimplifiedWeather): string {
+  const parts: string[] = [];
+
+  // Round the temperature to the nearest degree for brevity
+  const roundedTemp = Math.round(weather.temperature);
+  parts.push(`${roundedTemp}°C`);
+
+  // Prefer detailed description if available, otherwise fall back to main condition
+  const condition = weather.description || weather.condition;
+  parts.push(condition.toLowerCase());
+
+  // Mention rain if there is measurable volume
+  if (weather.rainVolume && weather.rainVolume > 0) {
+    parts.push("chance of rain");
+  }
+
+  // Convert wind speed from m/s to km/h and map to a simple descriptor
+  const windSpeedKmh = weather.wind.speed * 3.6;
+  let windDescriptor = "";
+  if (windSpeedKmh < 5) {
+    windDescriptor = "calm wind";
+  } else if (windSpeedKmh < 15) {
+    windDescriptor = "light wind";
+  } else if (windSpeedKmh < 30) {
+    windDescriptor = "moderate wind";
+  } else {
+    windDescriptor = "strong wind";
+  }
+  parts.push(windDescriptor);
+
+  return parts.join(", ");
+}

--- a/server/utils/summarizeWeather.ts
+++ b/server/utils/summarizeWeather.ts
@@ -13,8 +13,12 @@ export function summarizeWeather(weather: SimplifiedWeather): string {
   parts.push(`${roundedTemp}°C`);
 
   // Prefer detailed description if available, otherwise fall back to main condition
-  const condition = weather.description || weather.condition;
-  parts.push(condition.toLowerCase());
+  let condition = weather.description || weather.condition;
+  if (condition && condition.trim().length > 0) {
+    parts.push(condition.toLowerCase());
+  } else {
+    parts.push("unknown conditions");
+  }
 
   // Mention rain if there is measurable volume
   if (weather.rainVolume && weather.rainVolume > 0) {


### PR DESCRIPTION
## Summary
- add `summarizeWeather` to convert `SimplifiedWeather` into a short readable string
- include Jest test for the new helper

## Testing
- `npm test` in `server`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_687b59b5642c83299eb2afd9c90883d8