### PR TITLE
Add clothing suggestion prompt template

### DIFF
--- a/prompts/clothingSuggestion.ts
+++ b/prompts/clothingSuggestion.ts
@@ -1,0 +1,17 @@
+/// <reference path="../types/langchain-core-prompts.d.ts" />
+/// <reference path="../types/langchain-prompts.d.ts" />
+// Using require avoids issues with ESM package exports during Jest tests
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PromptTemplate } = require("@langchain/core/prompts");
+
+/**
+ * Prompt template instructing the model to provide short clothing advice.
+ * The `weather` variable should contain a human-readable weather summary.
+ */
+export const clothingSuggestionPrompt = new PromptTemplate({
+  inputVariables: ["weather"],
+  template:
+    "You are a friendly assistant that gives short clothing advice. " +
+    "Keep it under 25 words. Here is the weather data: {weather}",
+});
+

--- a/server/clothingSuggestionPrompt.test.ts
+++ b/server/clothingSuggestionPrompt.test.ts
@@ -1,0 +1,12 @@
+import { clothingSuggestionPrompt } from "../prompts/clothingSuggestion";
+
+describe("clothingSuggestionPrompt", () => {
+  it("injects the weather summary into the template", async () => {
+    const prompt = await clothingSuggestionPrompt.format({ weather: "10\u00B0C, rain" });
+    expect(prompt).toBe(
+      "You are a friendly assistant that gives short clothing advice. " +
+        "Keep it under 25 words. Here is the weather data: 10\u00B0C, rain"
+    );
+  });
+});
+

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -27,6 +27,7 @@
 
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
+    "moduleResolution": "node16",
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/types/langchain-core-prompts.d.ts
+++ b/types/langchain-core-prompts.d.ts
@@ -1,0 +1,10 @@
+declare module '@langchain/core/prompts' {
+  export class PromptTemplate {
+    constructor(args: any)
+    format(values: Record<string, any>): Promise<string>
+  }
+}
+
+declare module '@langchain/core/prompts.cjs' {
+  export { PromptTemplate } from '@langchain/core/prompts';
+}

--- a/types/langchain-prompts.d.ts
+++ b/types/langchain-prompts.d.ts
@@ -1,0 +1,10 @@
+declare module "langchain/prompts" {
+  export { PromptTemplate } from "@langchain/core/prompts";
+}
+
+declare module "langchain/dist/prompts" {
+  export { PromptTemplate } from "@langchain/core/prompts";
+}
+declare module "langchain/dist/prompts/index.cjs" {
+  export { PromptTemplate } from "@langchain/core/prompts";
+}


### PR DESCRIPTION
## Summary
- add PromptTemplate for clothing suggestions
- include tests for prompt formatting
- update tsconfig for node16 module resolution
- declare LangChain prompt module types

## Testing
- `npm test` *(fails: Cannot find module '@langchain/core/prompts' in clothingSuggestion.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687b6ef4ac348329944407fd5d07ed82