### PR TITLE
Add LangChain clothing suggestion service

### DIFF
--- a/server/getClothingSuggestion.test.ts
+++ b/server/getClothingSuggestion.test.ts
@@ -1,0 +1,23 @@
+const mockInvoke = jest.fn().mockResolvedValue("Wear a jacket.");
+
+jest.mock("langchain/llms/openai", () => ({
+  OpenAI: jest.fn().mockImplementation(() => ({
+    invoke: mockInvoke,
+  })),
+}));
+
+import { OpenAI } from "langchain/llms/openai";
+import { getClothingSuggestion } from "./utils/getClothingSuggestion";
+
+describe("getClothingSuggestion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the suggestion from the OpenAI model", async () => {
+    const result = await getClothingSuggestion("Tell me what to wear");
+    expect(result).toBe("Wear a jacket.");
+    expect(OpenAI).toHaveBeenCalledWith({ modelName: "gpt-4o", temperature: 0.2 });
+    expect(mockInvoke).toHaveBeenCalledWith("Tell me what to wear");
+  });
+});

--- a/server/utils/getClothingSuggestion.ts
+++ b/server/utils/getClothingSuggestion.ts
@@ -1,0 +1,11 @@
+import { OpenAI } from "langchain/llms/openai";
+
+/**
+ * Call OpenAI\'s GPT-4o model to get a clothing suggestion.
+ * @param prompt - Preformatted prompt describing the weather.
+ * @returns Suggested clothing text from the model.
+ */
+export async function getClothingSuggestion(prompt: string): Promise<string> {
+  const model = new OpenAI({ modelName: "gpt-4o", temperature: 0.2 });
+  return model.invoke(prompt);
+}


### PR DESCRIPTION
## Summary
- add `getClothingSuggestion` util calling LangChain's OpenAI
- test deterministic suggestion handling

## Testing
- `npm test --silent` in `server`
- `npm test --silent` in `client`


------
https://chatgpt.com/codex/tasks/task_e_687b86bbfc248329b2138f698dfcecf9