### PR TITLE
Add clothing suggestion service

### DIFF
--- a/client/src/utils/clothingService.test.ts
+++ b/client/src/utils/clothingService.test.ts
@@ -1,0 +1,36 @@
+jest.mock('axios');
+import axios from 'axios';
+import { getClothingSuggestion } from './clothingService';
+import { SimplifiedWeather } from '../../../types/SimplifiedWeather';
+
+describe('getClothingSuggestion', () => {
+  const weather: SimplifiedWeather = {
+    temperature: 12,
+    condition: 'Clouds',
+    humidity: 80,
+    pressure: 1010,
+    wind: { speed: 3, direction: 150 },
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('posts weather data and returns a suggestion', async () => {
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: { suggestion: 'Wear a coat.' },
+    });
+
+    const result = await getClothingSuggestion(weather);
+
+    expect(axios.post).toHaveBeenCalledWith('/suggest-clothing', weather);
+    expect(result).toBe('Wear a coat.');
+  });
+
+  it('throws when the request fails', async () => {
+    const error = new Error('Network error');
+    (axios.post as jest.Mock).mockRejectedValue(error);
+
+    await expect(getClothingSuggestion(weather)).rejects.toThrow('Network error');
+  });
+});

--- a/client/src/utils/clothingService.ts
+++ b/client/src/utils/clothingService.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+// Reuse the shared SimplifiedWeather interface from the root types folder
+import { SimplifiedWeather } from '../../../types/SimplifiedWeather';
+
+/**
+ * Request a clothing suggestion from the API based on weather data.
+ * @param weather SimplifiedWeather object describing current conditions.
+ * @returns Promise resolving to the suggestion text from the server.
+ */
+export const getClothingSuggestion = async (
+  weather: SimplifiedWeather
+): Promise<string> => {
+  try {
+    const response = await axios.post<{ suggestion: string }>(
+      '/suggest-clothing',
+      weather
+    );
+    return response.data.suggestion;
+  } catch (error) {
+    console.error('Error fetching clothing suggestion', error);
+    throw error;
+  }
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,5 +17,5 @@
     "jsx": "react-jsx",
     "types": ["jest", "node", "@testing-library/jest-dom"]
   },
-  "include": ["src", "jest.config.ts", "components/**/*.tsx"]
+  "include": ["src", "jest.config.ts", "components/**/*.tsx", "../types/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add `getClothingSuggestion` util for the client
- cover new util with unit tests
- include shared `types` directory in client tsconfig

## Testing
- `npm test --prefix client`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_687cbc65d1008329883906e5292d5d48